### PR TITLE
fix(content): remove strict organization check from team content endp…

### DIFF
--- a/src/routes/analysis.routes.ts
+++ b/src/routes/analysis.routes.ts
@@ -1,21 +1,40 @@
-import { Router } from 'express';
+import express from "express";
 import {
   createTemplate,
   getTemplate,
   updateTemplate,
   deleteTemplate,
   listTeamTemplates,
-  applyTemplate
-} from '../controllers/analysis.controller';
+  applyTemplate,
+  getPersonalTemplates,
+} from "../controllers/analysis.controller";
+import { authenticateToken, requireTeamAccess } from '../middleware/auth.middleware';
 
-const router = Router();
+const router = express.Router();
 
 // Analysis Template Routes
-router.post('/templates', createTemplate);
-router.get('/templates/:templateId', getTemplate);
-router.put('/templates/:templateId', updateTemplate);
-router.delete('/templates/:templateId', deleteTemplate);
-router.get('/templates/team/:teamId', listTeamTemplates);
-router.post('/templates/:templateId/apply/:contentId', applyTemplate);
+router.post('/templates', authenticateToken, (req, res) => {
+  return createTemplate(req, res);
+});
+router.get('/templates/:templateId', authenticateToken, (req, res) => {
+  return getTemplate(req, res);
+});
+router.put('/templates/:templateId', authenticateToken, (req, res) => {
+  return updateTemplate(req, res);
+});
+router.delete('/templates/:templateId', authenticateToken, (req, res) => {
+  return deleteTemplate(req, res);
+});
+router.get('/templates/team/:teamId', authenticateToken, requireTeamAccess, (req, res) => {
+  return listTeamTemplates(req, res);
+});
+router.post('/templates/:templateId/apply/:contentId', authenticateToken, (req, res) => {
+  return applyTemplate(req, res);
+});
+
+// Personal routes
+router.get("/personal/templates", authenticateToken, (req, res) => {
+  return getPersonalTemplates(req, res);
+});
 
 export default router;

--- a/src/routes/collections.routes.ts
+++ b/src/routes/collections.routes.ts
@@ -1,26 +1,52 @@
-import { Router } from 'express';
+import express from "express";
 import {
   createCollection,
   getCollection,
   updateCollection,
   deleteCollection,
+  listTeamCollections,
   addContentToCollection,
   removeContentFromCollection,
-  listTeamCollections
-} from '../controllers/collections.controller';
+  getPersonalCollections,
+} from "../controllers/collections.controller";
 import { authenticateToken, requireTeamAccess } from '../middleware/auth.middleware';
 
-const router = Router();
+const router = express.Router();
 
-// Collection Routes - all require authentication
-router.post('/', authenticateToken, createCollection);
-router.get('/:collectionId', authenticateToken, getCollection);
-router.put('/:collectionId', authenticateToken, updateCollection);
-router.delete('/:collectionId', authenticateToken, deleteCollection);
-router.post('/:collectionId/content/:contentId', authenticateToken, addContentToCollection);
-router.delete('/:collectionId/content/:contentId', authenticateToken, removeContentFromCollection);
+// Personal routes
+router.get("/personal", authenticateToken, (req, res) => {
+  return getPersonalCollections(req, res);
+});
 
-// Team collections require team access
-router.get('/team/:teamId', authenticateToken, requireTeamAccess, listTeamCollections);
+// Team routes
+router.get("/team/:teamId", authenticateToken, requireTeamAccess, (req, res) => {
+  return listTeamCollections(req, res);
+});
+
+// Standard CRUD routes
+router.post("/", authenticateToken, (req, res) => {
+  return createCollection(req, res);
+});
+
+router.get("/:collectionId", authenticateToken, (req, res) => {
+  return getCollection(req, res);
+});
+
+router.put("/:collectionId", authenticateToken, (req, res) => {
+  return updateCollection(req, res);
+});
+
+router.delete("/:collectionId", authenticateToken, (req, res) => {
+  return deleteCollection(req, res);
+});
+
+// Collection content management
+router.post("/:collectionId/content/:contentId", authenticateToken, (req, res) => {
+  return addContentToCollection(req, res);
+});
+
+router.delete("/:collectionId/content/:contentId", authenticateToken, (req, res) => {
+  return removeContentFromCollection(req, res);
+});
 
 export default router;

--- a/src/routes/content.routes.ts
+++ b/src/routes/content.routes.ts
@@ -8,6 +8,7 @@ import {
   listTeamContent,
   archiveContent,
   generateContent,
+  getPersonalContent,
 } from "../controllers/content.controller";
 import { authenticateToken, requireTeamAccess } from '../middleware/auth.middleware';
 
@@ -35,6 +36,11 @@ router.use((req, res, next) => {
 router.get("/test", (req, res) => {
   // console.log("[DEBUG] Test route hit");
   res.json({ message: "Content router is working" });
+});
+
+// Personal routes
+router.get("/personal", authenticateToken, (req, res) => {
+  return getPersonalContent(req, res);
 });
 
 // AI Content Generation route

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,8 +92,8 @@ export interface ContentItem {
     customAnalytics?: Record<string, any>;
   };
   status: 'pending' | 'analyzed' | 'archived';
-  teamId: string;
-  organizationId: string;
+  teamId: string | null;  // Null for individual users
+  organizationId: string | null;  // Null for individual users
   createdBy: string;  // User UID
   createdAt: Timestamp;
   updatedAt: Timestamp;
@@ -146,8 +146,8 @@ export interface AnalysisTemplate {
     preprocessors?: string[];
     postprocessors?: string[];
   };
-  teamId: string;
-  organizationId: string;
+  teamId: string | null;  // Null for individual users
+  organizationId: string | null;  // Null for individual users
   settings: {
     permissions: string[];
     autoApply: boolean;


### PR DESCRIPTION
…oint

- Remove unnecessary userType check from listTeamContent controller
- Keep team membership validation for security
- Maintain consistent permission model across content endpoints
- Allow both individual and organization users to access team content if they have proper permissions