### PR TITLE
feat(api): add Facebook page posting support alongside Instagram

### DIFF
--- a/src/controllers/platforms/facebook.controller.ts
+++ b/src/controllers/platforms/facebook.controller.ts
@@ -1,0 +1,78 @@
+import { Request, Response as ExpressResponse } from "express";
+import { postContent } from "../../services/platforms/facebook.service";
+import { getCollections } from "../../config/db";
+
+export const postToFacebook = async ({
+  req,
+  res,
+  postData,
+}: {
+  req?: Request;
+  res?: ExpressResponse;
+  postData?: any;
+}): Promise<any> => {
+  try {
+    const { accountId, content, mediaUrls, link } =
+      postData ?? req?.body?.data ?? {};
+    const userId = postData?.userId ?? (req as any)?.user?.id;
+
+    if (!accountId || !userId) {
+      const message = !accountId
+        ? "Account ID is required"
+        : "Authentication required";
+      res?.status(400).json({ status: "error", message });
+      return { success: false, error: message };
+    }
+
+    if (!content && (!mediaUrls || mediaUrls.length === 0) && !link) {
+      const message = "Post content, media, or link is required";
+      res?.status(400).json({ status: "error", message });
+      return { success: false, error: message };
+    }
+
+    const { socialaccounts } = await getCollections();
+    const account = await socialaccounts.findOne({
+      accountId,
+    });
+
+    if (!account || account.platform !== "facebook") {
+      const message = "Facebook account not found or invalid";
+      res?.status(404).json({ status: "error", message });
+      return { success: false, error: message };
+    }
+
+    if (account.userId.toString() !== userId) {
+      const message = "Unauthorized to post to this account";
+      res?.status(403).json({ status: "error", message });
+      return { success: false, error: message };
+    }
+
+    // Actual post
+    const postId = await postContent(
+      account.accountId,
+      account.accessToken,
+      content,
+      link,
+      mediaUrls
+    );
+
+    if (res) {
+      return res.status(200).json({
+        status: "success",
+        message: "Successfully posted to Facebook",
+        data: postId,
+      });
+    }
+
+    return { success: true, postId };
+  } catch (error: any) {
+    console.error("Error posting to Facebook:", error);
+    if (res) {
+      res.status(500).json({
+        status: "error",
+        message: error.message ?? "An unexpected error occurred",
+      });
+    }
+    return { success: false, error: error.message };
+  }
+};

--- a/src/controllers/platforms/meta.controller.ts
+++ b/src/controllers/platforms/meta.controller.ts
@@ -1,0 +1,176 @@
+import { Request, Response as ExpressResponse } from "express";
+import redisService from "../../utils/redisClient";
+import { getAuthorizationUrl } from "../../services/platforms/meta.service";
+import axios from "axios";
+import * as metaService from "../../services/platforms/meta.service";
+
+export const startDirectMetaOAuth = async (
+  req: Request,
+  res: ExpressResponse
+) => {
+  const { id: userId, organizationId, currentTeamId } = (req as any).user!;
+  const state = `${userId}:${Date.now()}`;
+
+  await redisService.set(
+    `meta:state:${state}`,
+    JSON.stringify({ userId, organizationId, currentTeamId }),
+    600
+  );
+
+  const redirectUri = getAuthorizationUrl(state);
+
+  res.send(redirectUri);
+};
+
+export const handleMetaCallback = async (
+  req: Request,
+  res: ExpressResponse
+) => {
+  const { code, state } = req.query;
+
+  if (!code || !state) {
+    res.redirect(
+      `${
+        process.env.FRONTEND_URL
+      }/dashboard/accounts?status=failed&message=${encodeURIComponent(
+        "Missing code or state"
+      )}`
+    );
+    return;
+  }
+
+  const stored = await redisService.get(`meta:state:${state as string}`);
+  if (!stored) return res.status(403).send("Invalid or expired state.");
+
+  const { userId, organizationId, currentTeamId } = JSON.parse(stored);
+
+  try {
+    // 1. Exchange code for access token
+    const tokenRes = await axios.post(
+      "https://graph.facebook.com/v19.0/oauth/access_token",
+      new URLSearchParams({
+        client_id: process.env.INSTAGRAM_CLIENT_ID!,
+        client_secret: process.env.INSTAGRAM_CLIENT_SECRET!,
+        grant_type: "authorization_code",
+        redirect_uri: process.env.META_REDIRECT_URI!,
+        code: code as string,
+      })
+    );
+
+    const userAccessToken = tokenRes.data.access_token;
+    const tokenExpiry = tokenRes.data.expires_in
+      ? Date.now() + tokenRes.data.expires_in * 1000
+      : null;
+
+    // 2. Fetch Facebook Pages
+    const pagesRes = await axios.get(
+      `https://graph.facebook.com/v19.0/me/accounts?access_token=${userAccessToken}`
+    );
+    const pages = pagesRes.data.data;
+    if (!pages || pages.length === 0) {
+      throw new Error("No Facebook Pages found for this user.");
+    }
+
+    let connectedIG = false;
+
+    for (const page of pages) {
+      const pageId = page.id;
+
+      // Fetch Page details
+      const pageDetailsRes = await axios.get(
+        `https://graph.facebook.com/v19.0/${pageId}?fields=name,instagram_business_account&access_token=${userAccessToken}`
+      );
+      const pageData = pageDetailsRes.data;
+
+      // Always save Facebook Page account
+      const fbAccountPayload = {
+        platform: "facebook" as "facebook" | "instagram",
+        accountType: "page",
+        accountName: pageData.name,
+        accountId: pageId,
+        platformAccountId: pageId,
+        accessToken: page.access_token, // This is the Page-level token
+        refreshToken: null,
+        tokenExpiry,
+        lastRefreshed: new Date(),
+        status: "active",
+        userId,
+        organizationId,
+        currentTeamId,
+        metadata: {
+          profileUrl: `https://facebook.com/${pageId}`,
+          profileImageUrl: null,
+          followerCount: 0,
+          fbPageId: pageId,
+          fbPageName: pageData.name,
+          lastChecked: new Date(),
+        },
+        permissions: {
+          canPost: true,
+          canSchedule: true,
+          canAnalyze: false,
+        },
+        connectedAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      await metaService.saveOrUpdateMetaAccount(fbAccountPayload);
+
+      // If Page has connected IG Business Account
+      if (pageData.instagram_business_account && !connectedIG) {
+        const igId = pageData.instagram_business_account.id;
+        const igProfileRes = await axios.get(
+          `https://graph.facebook.com/v19.0/${igId}?fields=username,profile_picture_url,followers_count&access_token=${userAccessToken}`
+        );
+        const igProfile = igProfileRes.data;
+
+        const igPayload = {
+          platform: "instagram" as "facebook" | "instagram",
+          accountType: "business",
+          accountName: igProfile.username,
+          accountId: igId,
+          platformAccountId: igId,
+          accessToken: userAccessToken,
+          refreshToken: null,
+          tokenExpiry,
+          lastRefreshed: new Date(),
+          status: "active",
+          userId,
+          organizationId,
+          currentTeamId,
+          metadata: {
+            profileUrl: `https://instagram.com/${igProfile.username}`,
+            profileImageUrl: igProfile.profile_picture_url,
+            followerCount: igProfile.followers_count,
+            fbPageId: pageId,
+            fbPageName: pageData.name,
+            lastChecked: new Date(),
+          },
+          permissions: {
+            canPost: true,
+            canSchedule: true,
+            canAnalyze: true,
+          },
+          connectedAt: new Date(),
+          updatedAt: new Date(),
+        };
+
+        await metaService.saveOrUpdateMetaAccount(igPayload);
+        connectedIG = true;
+      }
+    }
+
+    res.redirect(
+      `${process.env.FRONTEND_URL}/dashboard/accounts?status=success`
+    );
+  } catch (err: any) {
+    console.error("Instagram callback error:", err);
+    res.redirect(
+      `${
+        process.env.FRONTEND_URL
+      }/dashboard/accounts?status=failed&message=${encodeURIComponent(
+        err.message ?? "Unknown error"
+      )}`
+    );
+  }
+};

--- a/src/routes/platforms/facebook.routes.ts
+++ b/src/routes/platforms/facebook.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { postToFacebook } from "../../controllers/platforms/facebook.controller";
+import { requireJwtAuth } from "../../middlewares/auth";
+
+const router = Router();
+
+router.post("/:accountId/post", requireJwtAuth, (req, res) =>
+  postToFacebook({ req, res })
+);
+
+export default router;

--- a/src/routes/platforms/instagram.routes.ts
+++ b/src/routes/platforms/instagram.routes.ts
@@ -1,15 +1,15 @@
 import { Router } from "express";
-import * as instagramController from "../../controllers/platforms/instagram.controller";
+import {
+  startDirectInstagramOAuth,
+  handleInstagramCallback,
+  post,
+} from "../../controllers/platforms/instagram.controller";
 import { requireJwtAuth } from "../../middlewares/auth";
 
 const router = Router();
 
-router.get(
-  "/direct-auth",
-  requireJwtAuth,
-  instagramController.startDirectInstagramOAuth
-);
-router.get("/callback", instagramController.handleInstagramCallback);
-router.post("/:accountId/post", requireJwtAuth, instagramController.post);
+router.get("/direct-auth", requireJwtAuth, startDirectInstagramOAuth);
+router.get("/callback", handleInstagramCallback);
+router.post("/:accountId/post", requireJwtAuth, post);
 
 export default router;

--- a/src/routes/platforms/meta.routes.ts
+++ b/src/routes/platforms/meta.routes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import {
+  startDirectMetaOAuth,
+  handleMetaCallback,
+} from "../../controllers/platforms/meta.controller";
+import { requireJwtAuth } from "../../middlewares/auth";
+
+const router = Router();
+
+router.get("/direct-auth", requireJwtAuth, startDirectMetaOAuth);
+router.get("/callback", handleMetaCallback);
+
+export default router;

--- a/src/routes/socialAccount.routes.ts
+++ b/src/routes/socialAccount.routes.ts
@@ -1,10 +1,21 @@
 import { Router } from "express";
-import * as socialAccountController from "../controllers/socialAccount.controller";
+import {
+  getSocialAccountsByOrganizationId,
+  linkSocialAccount,
+  listSocialAccounts,
+  updateSocialAccount,
+  unlinkSocialAccount,
+  getPersonalAccount,
+  assignSocialAccountToTeam,
+  listSocialAccountsByTeam,
+} from "../controllers/socialAccount.controller";
 import { requireJwtAuth } from "../middlewares/auth";
 import twitterRoutes from "./platforms/twitter.routes";
 import linkedinRoutes from "./platforms/linkedin.routes";
 import threadsRoutes from "./platforms/threads.routes";
 import instagramRoutes from "./platforms/instagram.routes";
+import metaRoutes from "./platforms/meta.routes";
+import facebookRoutes from "./platforms/facebook.routes";
 
 const router = Router();
 
@@ -13,57 +24,31 @@ router.use("/twitter", twitterRoutes);
 router.use("/linkedin", linkedinRoutes);
 router.use("/threads", threadsRoutes);
 router.use("/instagram", instagramRoutes);
+router.use("/meta", metaRoutes);
+router.use("/facebook", facebookRoutes);
 
 // Get Social Accounts by Organization
-router.get(
-  "/",
-  requireJwtAuth,
-  socialAccountController.getSocialAccountsByOrganizationId
-);
+router.get("/", requireJwtAuth, getSocialAccountsByOrganizationId);
 
 // Link Social Account
-router.post("/", requireJwtAuth, socialAccountController.linkSocialAccount);
+router.post("/", requireJwtAuth, linkSocialAccount);
 
 // List Social Accounts
-router.get(
-  "/:userId",
-  requireJwtAuth,
-  socialAccountController.listSocialAccounts
-);
+router.get("/:userId", requireJwtAuth, listSocialAccounts);
 
 // Update Social Account
-router.patch(
-  "/:id",
-  requireJwtAuth,
-  socialAccountController.updateSocialAccount
-);
+router.patch("/:id", requireJwtAuth, updateSocialAccount);
 
 // Unlink Social Account
-router.delete(
-  "/disconnect/:id",
-  requireJwtAuth,
-  socialAccountController.unlinkSocialAccount
-);
+router.delete("/disconnect/:id", requireJwtAuth, unlinkSocialAccount);
 
 // Get Personal Account (userType: "personal")
-router.get(
-  "/:accountId",
-  requireJwtAuth,
-  socialAccountController.getPersonalAccount
-);
+router.get("/:accountId", requireJwtAuth, getPersonalAccount);
 
 // Assign/Unassign Social Account to Team
-router.patch(
-  "/:id/assign",
-  requireJwtAuth,
-  socialAccountController.assignSocialAccountToTeam
-);
+router.patch("/:id/assign", requireJwtAuth, assignSocialAccountToTeam);
 
 // List social accounts by team
-router.get(
-  "/team/:teamId",
-  requireJwtAuth,
-  socialAccountController.listSocialAccountsByTeam
-);
+router.get("/team/:teamId", requireJwtAuth, listSocialAccountsByTeam);
 
 export default router;

--- a/src/services/platforms/facebook.service.ts
+++ b/src/services/platforms/facebook.service.ts
@@ -1,0 +1,78 @@
+import axios from "axios";
+import { getCollections } from "../../config/db";
+import { ObjectId } from "mongodb";
+
+export const postContent = async (
+  pageId: string,
+  pageAccessToken: string,
+  message: string,
+  link?: string,
+  mediaUrls?: string[]
+): Promise<{ success: boolean; postId: string }> => {
+  const { socialposts, socialaccounts } = await getCollections();
+
+  const account = await socialaccounts.findOne({
+    accountId: pageId,
+    platform: "facebook",
+  });
+  if (!account) throw new Error("Facebook page not found");
+
+  const postPayload: Record<string, string> = {
+    message,
+    access_token: pageAccessToken,
+  };
+
+  if (link) {
+    postPayload.link = link;
+  }
+
+  let postRes;
+  let photoRes;
+
+  if (mediaUrls && mediaUrls.length > 0) {
+    photoRes = await axios.post(
+      `https://graph.facebook.com/v19.0/${pageId}/photos`,
+      new URLSearchParams({
+        url: mediaUrls[0], // only one at a time supported
+        caption: message,
+        access_token: pageAccessToken,
+      })
+    );
+  } else {
+    postRes = await axios.post(
+      `https://graph.facebook.com/v19.0/${pageId}/feed`,
+      new URLSearchParams(postPayload)
+    );
+  }
+
+  const postId = postRes?.data.id ?? photoRes?.data.id;
+  const now = new Date();
+
+  await socialposts.insertOne({
+    userId: account.userId,
+    teamId: account.currentTeamId ? new ObjectId(account.currentTeamId) : null,
+    organizationId: account.organizationId
+      ? new ObjectId(account.organizationId)
+      : null,
+    socialAccountId: account._id,
+    platform: "facebook",
+    content: message,
+    mediaType: link ? "LINK" : "TEXT",
+    mediaUrls: link ? [link] : mediaUrls,
+    postId,
+    status: "published",
+    publishedDate: now,
+    createdAt: now,
+    updatedAt: now,
+    metadata: {
+      platform: "facebook",
+      accountId: account.accountId,
+      accountName: account.accountName,
+      accountType: account.accountType,
+      profileUrl: `https://facebook.com/${account.accountId}`,
+      profileImageUrl: null, // You can later query profile image
+    },
+  });
+
+  return { success: true, postId };
+};

--- a/src/services/platforms/meta.service.ts
+++ b/src/services/platforms/meta.service.ts
@@ -1,0 +1,79 @@
+import { getCollections } from "../../config/db";
+import { ObjectId } from "mongodb";
+
+const INSTAGRAM_CLIENT_ID = process.env.INSTAGRAM_CLIENT_ID!;
+const META_REDIRECT_URI = process.env.META_REDIRECT_URI!;
+
+export interface MetaAccountPayload {
+  platform: "instagram" | "facebook";
+  accountType: string;
+  accountName: string;
+  accountId: string;
+  accessToken: string;
+  refreshToken: string | null;
+  tokenExpiry: number | null;
+  lastRefreshed: Date;
+  status: string;
+  userId: string;
+  organizationId: string | null;
+  currentTeamId: string | null;
+  metadata: Record<string, any>;
+  permissions: {
+    canPost: boolean;
+    canSchedule: boolean;
+    canAnalyze: boolean;
+  };
+  connectedAt: Date;
+  updatedAt: Date;
+}
+
+export const getAuthorizationUrl = (state: string) => {
+  const base = "https://www.facebook.com/v19.0/dialog/oauth";
+  const params = new URLSearchParams({
+    client_id: INSTAGRAM_CLIENT_ID,
+    redirect_uri: META_REDIRECT_URI,
+    scope:
+      "pages_show_list,instagram_basic,instagram_content_publish,pages_read_engagement,pages_manage_posts,business_management",
+    response_type: "code",
+    state,
+  });
+  return `${base}?${params.toString()}`;
+};
+
+export const saveOrUpdateMetaAccount = async (payload: MetaAccountPayload) => {
+  const { socialaccounts } = await getCollections();
+
+  const existing = await socialaccounts.findOne({
+    platform: payload.platform,
+    accountId: payload.accountId,
+  });
+
+  if (existing && existing.userId.toString() !== payload.userId) {
+    throw new Error(
+      `This ${payload.platform} account is already connected by another user.`
+    );
+  }
+
+  const dbPayload = {
+    ...payload,
+    userId: new ObjectId(payload.userId),
+    organizationId: payload.organizationId
+      ? new ObjectId(payload.organizationId)
+      : null,
+    currentTeamId: payload.currentTeamId
+      ? new ObjectId(payload.currentTeamId)
+      : null,
+  };
+
+  if (existing) {
+    await socialaccounts.updateOne(
+      { _id: existing._id },
+      { $set: { ...dbPayload, updatedAt: new Date() } }
+    );
+  } else {
+    await socialaccounts.insertOne({
+      ...dbPayload,
+      createdAt: new Date(),
+    });
+  }
+};

--- a/src/services/socialPosts.service.ts
+++ b/src/services/socialPosts.service.ts
@@ -6,6 +6,7 @@ import {
 } from "../utils/cloudinary";
 import { postToThreads } from "../controllers/platforms/threads.controller";
 import { postToTwitter } from "../controllers/platforms/twitter.controller";
+import { postToFacebook } from "../controllers/platforms/facebook.controller";
 import { Response as ExpressResponse } from "express";
 import { postToInstagram } from "../controllers/platforms/instagram.controller";
 import { lookupCollectionDetails } from "../utils/mongoAggregations";
@@ -141,19 +142,24 @@ export async function handlePlatformUploadAndPost({
     };
 
     switch (platform) {
-      case "threads": {
-        await postToThreads({ postData: payload, res });
-        break;
-      }
-      case "twitter": {
-        await postToTwitter({ postData: payload, res });
-        return { success: true };
-      }
+      // Instagram Complete
       case "instagram": {
         await postToInstagram({
           postData: payload,
           res,
         });
+        return { success: true };
+      }
+      case "facebook": {
+        await postToFacebook({ postData: payload, res });
+        return { success: true };
+      }
+      case "threads": {
+        await postToThreads({ postData: payload, res });
+        return { success: true };
+      }
+      case "twitter": {
+        await postToTwitter({ postData: payload, res });
         return { success: true };
       }
       case "linkedin":


### PR DESCRIPTION
- Created Facebook controller, routes, and service to support post publishing to Facebook Pages
- Integrated Facebook support into shared multi-platform post handler
- Extended postToPlatforms endpoint logic to accommodate Facebook media and text
- Preserved Instagram functionality with backward-compatible changes
- Added Facebook post validation and fallback to /photos endpoint for image publishing